### PR TITLE
Clarify json files

### DIFF
--- a/project/Deliverable1.md
+++ b/project/Deliverable1.md
@@ -16,7 +16,7 @@ The dataset zip file can be found here: [courses.zip](courses.zip)
 
 A **valid** dataset: 
 - Has to be a valid zip file; this zip will contain many files under a folder called `courses/`. 
-- Valid courses will only be `.json` files.
+- Valid courses will always be in JSON format.
 - Each JSON file represents a course and can contain zero or more course sections. 
 - A valid dataset has to contain **at least one valid course section** that meets the requirements above.
 


### PR DESCRIPTION
The JSON files in courses.zip don't actually have the .json extension even though they are in fact JSON, so this phrasing is more correct.