### PR TITLE
Overhaul labs.md, remove references to DevPlans

### DIFF
--- a/project/Labs.md
+++ b/project/Labs.md
@@ -1,32 +1,8 @@
-# Labs (after the first week)
+# Labs
 
-There are three kinds of labs in this course:
+## Retrospective Labs
 
-1. Planning lab. These happen during the first week a deliverable is released.
-2. Milestone labs. All labs between planning and debrief.
-3. Retrospective lab. These happen the week following a deliverable being due.
-
-While planning and deliverable labs take place during the same physical lab time, it is easier to describe them independently.
-
-## Planning Lab
-
-The planning lab is an opportunity for a development team to devise a development plan for the deliverable. This will involve creating a set of milestones (at least one per week), each consisting of a set of specific development tasks. Each task should be assigned to a team member.
-
-The planning document should be called ```DevPlan-DXXX.md``` where ```XXX``` is the deliverable number. It should be checked into the root of the project repository. The TA will visit each group by the end of the lab to ensure the DevPlan is complete.
-
-While it will be sufficient to use this document alone to plan your development effort, you are encouraged to use Github's issue and project features to make it easier to discuss specific technical issues and to link commits and tasks together. If you use these other resources, linking to them from the DevPlan will help make it easier to track your progress. This will also ease communication with your partner as issues for the course project, and comments therein, will not be lost among all of your other personal email and texts.
-
-## Milestone Labs
-
-These are the labs during the term where you will work together with your teammate to make sure you are on target for the deliverable due date. TAs will be available during these times to help you with specific roadblocks you have encountered. TAs will probably not be able to sort out specific environment problems on your computer, but your other lab mates should be able to help with these.
-
-NOTE: TAs will necessarily be _reserved_ in their answers during the labs. While they will try to help you, they will not make your design decisions or write your code for you. Expect them to push for additional logging, debugging, or tests if you are encountering situations you do not understand. 
-
-During the milestone labs, the TAs will visit each group to check the team's progress against the DevPlan to see in what ways the team is ahead & behind schedule.
-
-## Retrospective Lab
-
-Deliverable retrospectives will always take place in lab the week each deliverable is due. During the retrospective, each team member will individually talk with the TAs to describe their deliverable. Expect questions about your design, data structures, algorithms, and development challenges. The TAs may also ask to see specific commits of source code in your repository and to see your development history. The debrief will be used to assign your deliverable multiplier (as described in the [syllabus](../README.md)). 
+Deliverable retrospectives are mandetory labs that take place in lab the week each deliverable is due. During the retrospective, each team member will individually talk with the TAs to describe their deliverable. Expect questions about your design, data structures, algorithms, and development challenges. The TAs may also ask to see specific commits of source code in your repository and to see your development history. The debrief will be used to assign your deliverable multiplier (as described in the [syllabus](../README.md)). 
 
 Students who have not adequately contributed to their group's progress can expect to have difficulty with the retrospective. It is expected that you will have shared the development tasks; while you should be able to describe your own work in detail, you should also have a workable understanding about your partner's code as well.
 
@@ -36,4 +12,14 @@ The D1, D2, and D3 debrief labs are also the D2, D3, and D4 planning labs, so wh
 
 Missing your retrospective lab or failing to commit your contribution file (as described in the deliverable description) will result in a retrospective score of 0. 
 
+## Milestone Labs
 
+These are the rest of the labs during the term where you will work together with your teammate to make sure you are on target for the deliverable due date. TAs will be available during these times to help you with specific roadblocks you have encountered. TAs will probably not be able to sort out specific environment problems on your computer, but your other lab mates should be able to help with these.
+
+NOTE: TAs will necessarily be _reserved_ in their answers during the labs. While they will try to help you, they will not make your design decisions or write your code for you. Expect them to push for additional logging, debugging, or tests if you are encountering situations you do not understand. 
+
+While these labs are not mandetory, they are a great time to meet with your partner in person to check in and plan out the next week, as well as get assistance from your TAs as office hours can get quite busy.
+
+## Early Weeks and Group Formation
+
+You will need to form a group for the course project, and coming to labs is one of the best ways to find someone to partner with. If you do not have a partner, coming to labs during the team formation period (typically after Deliverable 0) is critical as TAs will help you get into a group.


### PR DESCRIPTION
Remove planning lab, references to dev plans. Push for attendance during team formation period.