### PR TITLE
Added a clarification to dataset PUT

### DIFF
--- a/project/Deliverable3.md
+++ b/project/Deliverable3.md
@@ -34,7 +34,7 @@ You will adapt your existing ```InsightFacade``` to also be accessed using REST 
 
 * **```GET /```** returns the frontend UI; this will already be implemented for you.
 
-* **```PUT /dataset/:id/:kind```** allows to submit a zip file that will be parsed and used for future queries. The zip file content will be sent 'raw' as a buffer, you will need to convert it to base64 server side.
+* **```PUT /dataset/:id/:kind```** allows to submit a zip file that will be parsed and used for future queries. The zip file content will be sent 'raw' as a buffer, you will need to convert it to base64 server side. The body type of the request will be `multipart/form-data` and not `application/zip`.
   * Response Codes:
     * ```200```: When ```InsightFacade.addDataset()``` resolves.
     * ```400```: When ```InsightFacade.addDataset()``` rejects.


### PR DESCRIPTION
This part of the spec was quite confusing to me as I expected that by 'raw', it was meant that the file would just be sent as the content of the body. But by the looking at the tests, it appears that it should actually be sent as a field in a form submission. 