### PR TITLE
Fixing broken Async.md reading link

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This is a high-level overview of what the course will be about. Expect this list
 
 | Week					| Topic & Readings 	| Survey |
 |---					|---					|--- |
-| Week 0: Sept 2		| [Introduction](https://github.com/ubccpsc/310/blob/master/resources/readings/Introduction.md), [Teamwork](https://github.com/ubccpsc/310/blob/master/resources/readings/Teamwork.md), [Languages](https://github.com/ubccpsc/310/blob/master/resources/readings/Languages.md), & [Async](readings/Async.md) | Week 0 Survey - TBD (Due Sept 9) |
+| Week 0: Sept 2		| [Introduction](https://github.com/ubccpsc/310/blob/master/resources/readings/Introduction.md), [Teamwork](https://github.com/ubccpsc/310/blob/master/resources/readings/Teamwork.md), [Languages](https://github.com/ubccpsc/310/blob/master/resources/readings/Languages.md), & [Async](https://github.com/ubccpsc/310/blob/master/resources/readings/Async.md) | Week 0 Survey - TBD (Due Sept 9) |
 | Week 1: Sept 9		| [Testing](https://github.com/ubccpsc/310/blob/master/resources/readings/Testing.md) | Week 1 Survey - TBD |
 | Week 2: Sept 16	| [Process & Agile](https://github.com/ubccpsc/310/blob/master/resources/readings/Process.md) | Week 2 Survey - TBD |
 | Week 3: Sept 23	| [Specifications](https://github.com/ubccpsc/310/blob/master/resources/readings/Specifications.md) & [User Stories](https://github.com/ubccpsc/310/blob/master/resources/readings/SpecificationsUserStories.md) | Week 3 Survey - TBD |

--- a/README.md
+++ b/README.md
@@ -96,21 +96,18 @@ For admin-related questions (questions about late surveys/deliverables, illness,
 * Ada Li
 * Annie Wang
 * Arash Haj
+* Braxton Hall
 * Chi Duong
 * Eishan Lawrence
 * Harman Gakhal
-* Kenny Kwan
 * Ivan Zhang
-* Arash Haj
-* Chi Duong
-* Harman Gakhal
+* James Yoo
+* Kenny Kwan
 * Noa Heyl
 * Oscar Tu
+* Will Zhang
 * Yilan Yan
 * Yvonne Li
-* Will Zhang
-* Braxton Hall
-* James Yoo
 
 *TA Office Hours*:
 


### PR DESCRIPTION
@rtholmes should probably merge this in before the survey associated with the `Async.md` reading is due.