### PR TITLE
Issue: Broken reading link for Teamwork.md

### DIFF
--- a/resources/readings/Teamwork.md
+++ b/resources/readings/Teamwork.md
@@ -110,7 +110,7 @@ It is extremely important that you remember that your partner is your **best** r
 
 * On [dependence, independence, and interdependence](https://carogiana.wordpress.com/personal-essays/dependence-independence-interdependence-codependence/) from a psychological point of view.
 
-* Another [view](https://classes.soe.ucsc.edu/cmps115/Spring01/staff/teams.html) on SE teamwork.
+* Another [view](https://classes.soe.ucsc.edu/cmps115/Spring01/staff/teams.html) on SE teamwork. 
 
 <!--
 * Pres1: http://www.slideshare.net/ct231/teamwork-presentation-2012-15054766


### PR DESCRIPTION
@rtholmes 

It looks like the 310 repo doesn't have the ability for me to open issues, so I guess I'm stuck alerting you like this - my bad.

There was a student on Piazza who found a dead link for the `Teamwork.md` reading. Given that it's a reference, I don't think it's super important because they don't really need it to complete the survey. 

That being said we should probably either replace/remove this link to prevent confusion in the future.